### PR TITLE
Add support for dynamic widgets segment on top of stable 3.1 version

### DIFF
--- a/PackagingProject/Package.appxmanifest
+++ b/PackagingProject/Package.appxmanifest
@@ -8,13 +8,13 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="14082CryzenTechnologies.RoundedTB"
-    Publisher="CN=26093D81-5B64-4610-8EFB-00B295E6FE81"
-    Version="1.3.1.0" />
+    Name="ags76.RoundedTB11"
+    Publisher="CN=ags76"
+    Version="0.9.1.0" />
 
   <Properties>
     <DisplayName>RoundedTB</DisplayName>
-    <PublisherDisplayName>TorchGM</PublisherDisplayName>
+    <PublisherDisplayName>AGS76</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
 
@@ -32,7 +32,7 @@
       Executable="RoundedTB.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="RoundedTB"
+        DisplayName="RoundedTB11"
         Description="Adds rounded corners, margins and segments to your taskbar!"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"

--- a/PackagingProject/RoundedTB.Package.wapproj
+++ b/PackagingProject/RoundedTB.Package.wapproj
@@ -76,7 +76,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-    <PackageCertificateThumbprint>949AB122C53DAF37D8272CA0AA2350D81DDE2329</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>65B3BF39879A0D3979ADB7FAA801E49302EF2268</PackageCertificateThumbprint>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
@@ -84,6 +84,7 @@
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <EntryPointProjectUniqueName>..\RoundedTB\RoundedTB.csproj</EntryPointProjectUniqueName>
     <AppxSymbolPackageEnabled>True</AppxSymbolPackageEnabled>
+    <PackageCertificateKeyFile>RoundedTB.Package_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <AppxBundle>Always</AppxBundle>
@@ -186,6 +187,7 @@
     <Content Include="Images\Wide310x150Logo.scale-150.png" />
     <Content Include="Images\Wide310x150Logo.scale-200.png" />
     <Content Include="Images\Wide310x150Logo.scale-400.png" />
+    <None Include="RoundedTB.Package_TemporaryKey.pfx" />
     <None Include="Package.StoreAssociation.xml" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />

--- a/RoundedTB/Background.cs
+++ b/RoundedTB/Background.cs
@@ -122,10 +122,14 @@ namespace RoundedTB
                             if (settings.ShowTrayOnHover)
                             {
                                 LocalPInvoke.RECT currentTrayRect = taskbars[current].TrayRect;
+                                LocalPInvoke.RECT currentWidgetsRect = taskbars[current].TaskbarRect;
+                                currentWidgetsRect.Right = Convert.ToInt32(currentWidgetsRect.Right - (currentWidgetsRect.Right - currentWidgetsRect.Left) + (168 * taskbars[current].ScaleFactor));
+
                                 if (currentTrayRect.Left != 0)
                                 {
                                     LocalPInvoke.GetCursorPos(out LocalPInvoke.POINT msPt);
                                     bool isHoveringOverTray = LocalPInvoke.PtInRect(ref currentTrayRect, msPt);
+                                    bool isHoveringOverWidgets = LocalPInvoke.PtInRect(ref currentWidgetsRect, msPt);
                                     if (isHoveringOverTray && !settings.ShowTray)
                                     {
                                         settings.ShowTray = true;
@@ -135,6 +139,17 @@ namespace RoundedTB
                                     {
                                         settings.ShowTray = false;
                                         taskbars[current].Ignored = true;
+                                    }
+
+                                    if (isHoveringOverWidgets && !settings.ShowWidgets)
+                                    {
+                                        settings.ShowWidgets = true;
+                                        taskbars[current].Ignored = true;
+                                    }
+                                    else if (!isHoveringOverWidgets)
+                                    {
+                                        taskbars[current].Ignored = true;
+                                        settings.ShowWidgets = false;
                                     }
 
                                 }

--- a/RoundedTB/Interaction.cs
+++ b/RoundedTB/Interaction.cs
@@ -61,6 +61,7 @@ namespace RoundedTB
                         IsDynamic = false,
                         IsCentred = false,
                         ShowTray = false,
+                        ShowWidgets = false,
                         CompositionCompat = false,
                         IsNotFirstLaunch = false
                     };
@@ -78,6 +79,7 @@ namespace RoundedTB
                         IsDynamic = false,
                         IsCentred = false,
                         ShowTray = false,
+                        ShowWidgets = false,
                         CompositionCompat = false,
                         IsNotFirstLaunch = false
                     };
@@ -179,13 +181,15 @@ namespace RoundedTB
                             Debug.WriteLine(vkey);
                             if (vkey == 0x71)
                             {
-                                if (mw.showTrayCheckBox.IsChecked == true)
+                                if (mw.showTrayCheckBox.IsChecked == true || mw.showWidgetsCheckBox.IsChecked == true)
                                 {
                                     mw.showTrayCheckBox.IsChecked = false;
+                                    mw.showWidgetsCheckBox.IsChecked = false;
                                 }
                                 else
                                 {
                                     mw.showTrayCheckBox.IsChecked = true;
+                                    mw.showWidgetsCheckBox.IsChecked = true;
                                 }
                                 mw.ApplyButton_Click(null, null);
                             }

--- a/RoundedTB/MainWindow.xaml
+++ b/RoundedTB/MainWindow.xaml
@@ -27,11 +27,11 @@
         <Label x:Name="cornerRadiusLabel" Content="Corner radius" HorizontalAlignment="Left" Height="19" VerticalAlignment="Top" Width="119" Margin="10,104,0,0"/>
 
         <TextBox x:Name="marginInput" TextWrapping="NoWrap" Text="" Margin="10,62,0,0" Height="32" VerticalAlignment="Top" HorizontalAlignment="Left" Width="125"/>
-        <Button x:Name="advancedMarginsButton" Content="..." Style="{StaticResource AccentButtonStyle}" Visibility="Hidden" Margin="106,65,0,0" VerticalAlignment="Top" Height="26" Width="26" FontSize="12" Click="advancedMarginsButton_Click"/>
+        <Button x:Name="advancedMarginsButton" Content="..." Visibility="Hidden" Margin="106,65,0,0" VerticalAlignment="Top" Height="26" Width="26" FontSize="12" Click="advancedMarginsButton_Click"/>
         <Slider x:Name="marginSlider" Margin="10,30,0,0" Height="32" VerticalAlignment="Top" HorizontalAlignment="Left" Width="125" ValueChanged="marginSlider_ValueChanged" LargeChange="0" SmallChange="1" Focusable="False" Maximum="24" Orientation="Horizontal" Thumb.DragCompleted="marginSlider_DragCompleted"/>
         <TextBox x:Name="cornerRadiusInput" TextWrapping="NoWrap" Text="" Margin="10,160,0,0" Height="32" VerticalAlignment="Top" HorizontalAlignment="Left" Width="125"/>
         <Slider x:Name="cornerRadiusSlider" Margin="10,128,0,0" Height="32" VerticalAlignment="Top" HorizontalAlignment="Left" Width="125" ValueChanged="cornerRadiusSlider_ValueChanged" LargeChange="0" SmallChange="1" Focusable="False" Maximum="48" Orientation="Horizontal" Thumb.DragCompleted="cornerRadiusSlider_DragCompleted"/>
-        <Button x:Name="applyButton" Content="Apply" Style="{StaticResource AccentButtonStyle}" Margin="10,290,0,0" Click="ApplyButton_Click" Height="32" Width="125" VerticalAlignment="Top" />
+        <Button x:Name="applyButton" Content="Apply" Margin="10,290,0,0" Click="ApplyButton_Click" Height="32" Width="125" VerticalAlignment="Top" />
         <Button x:Name="advancedButton" Content="Advanced" Margin="10,204,0,0" Width="125" Click="advancedButton_Click" VerticalAlignment="Top"/>
         <Button x:Name="aboutButton" Content="Help &amp; About" Margin="10,247,0,0" VerticalAlignment="Top" Width="125" Click="aboutButton_Click"/>
 
@@ -49,7 +49,7 @@
             <TextBox x:Name="mRightInput" HorizontalAlignment="Left" Margin="107,85,0,0" TextWrapping="NoWrap" Text="" VerticalAlignment="Top" Width="94" IsEnabled="False"/>
 
             <CheckBox x:Name="dynamicCheckBox" Content="Dynamic mode" Margin="0,122,0,0" Checked="dynamicCheckBox_Checked" Unchecked="dynamicCheckBox_Unchecked" VerticalAlignment="Top"/>
-            <Button x:Name="splitHelpButton" Content="Click me!" Style="{StaticResource AccentButtonStyle}" Margin="107,122,0,0" Click="splitHelpButton_Click"  Height="32" Width="94" VerticalAlignment="Top" FontWeight="Normal" FontFamily="Segoe UI Semibold" Visibility="Hidden"/>
+            <Button x:Name="splitHelpButton" Content="Click me!" Margin="107,122,0,0" Click="splitHelpButton_Click"  Height="32" Width="94" VerticalAlignment="Top" FontWeight="Normal" FontFamily="Segoe UI Semibold" Visibility="Hidden"/>
             <CheckBox x:Name="centredCheckBox" Content="Centred taskbar?" Margin="10,62,0,0" VerticalAlignment="Top" Visibility="Hidden"/>
             <CheckBox x:Name="showWidgetsCheckBox" Content="Show widgets (Win+F2)" Margin="0,155,0,0" VerticalAlignment="Top"/>
             <CheckBox x:Name="showTrayCheckBox" Content="Show system tray (Win+F2)" Margin="0,187,0,0" VerticalAlignment="Top"/>

--- a/RoundedTB/MainWindow.xaml
+++ b/RoundedTB/MainWindow.xaml
@@ -6,12 +6,12 @@
         xmlns:local="clr-namespace:RoundedTB"
         xmlns:tb="http://www.hardcodet.net/taskbar"
         mc:Ignorable="d"
-        Title="RoundedTB" Height="363" Width="169"
+        Title="RoundedTB" Height="395" Width="169"
         xmlns:ui="http://schemas.modernwpf.com/2019"
         ui:WindowHelper.UseModernWindowStyle="True" Opacity="0.001" Visibility = "Visible" ResizeMode="NoResize">
     <!--169, 393-->
     <Grid HorizontalAlignment="Left" Margin="11,-6,0,0" Width="357">
-        <tb:TaskbarIcon x:Name="TrayIcon" Visibility ="Visible" ToolTipText="RoundedTB" Height="347" VerticalAlignment="Top" Margin="0,6,0,0">
+        <tb:TaskbarIcon x:Name="TrayIcon" Visibility ="Visible" ToolTipText="RoundedTB" Height="379" VerticalAlignment="Top" Margin="0,6,0,0">
             <tb:TaskbarIcon.ContextMenu>
                 <ContextMenu MouseEnter="ContextMenu_MouseEnter">
                     <CheckBox x:Name ="StartupCheckBox" Content="Run at startup" Click="Startup_Clicked"/>
@@ -35,7 +35,7 @@
         <Button x:Name="advancedButton" Content="Advanced" Margin="10,204,0,0" Width="125" Click="advancedButton_Click" VerticalAlignment="Top"/>
         <Button x:Name="aboutButton" Content="Help &amp; About" Margin="10,247,0,0" VerticalAlignment="Top" Width="125" Click="aboutButton_Click"/>
 
-        <Grid x:Name="AdvancedGrid" Margin="156,6,0,0" HorizontalAlignment="Left" Width="201" Height="347" VerticalAlignment="Top" Visibility="Visible">
+        <Grid x:Name="AdvancedGrid" Margin="156,6,0,0" HorizontalAlignment="Left" Width="201" Height="379" VerticalAlignment="Top" Visibility="Visible">
             <Label x:Name="mTopLabel" Content="Top Margin" HorizontalAlignment="Left" VerticalAlignment="Top" Width="94"/>
             <TextBox x:Name="mTopInput" HorizontalAlignment="Left" Margin="0,24,0,0" TextWrapping="NoWrap" Text="" VerticalAlignment="Top" Width="94" IsEnabled="False"/>
 
@@ -51,11 +51,12 @@
             <CheckBox x:Name="dynamicCheckBox" Content="Dynamic mode" Margin="0,122,0,0" Checked="dynamicCheckBox_Checked" Unchecked="dynamicCheckBox_Unchecked" VerticalAlignment="Top"/>
             <Button x:Name="splitHelpButton" Content="Click me!" Style="{StaticResource AccentButtonStyle}" Margin="107,122,0,0" Click="splitHelpButton_Click"  Height="32" Width="94" VerticalAlignment="Top" FontWeight="Normal" FontFamily="Segoe UI Semibold" Visibility="Hidden"/>
             <CheckBox x:Name="centredCheckBox" Content="Centred taskbar?" Margin="10,62,0,0" VerticalAlignment="Top" Visibility="Hidden"/>
-            <CheckBox x:Name="showTrayCheckBox" Content="Show system tray (Win+F2)" Margin="0,155,0,0" VerticalAlignment="Top"/>
-            <CheckBox x:Name="showTrayOnHoverCheckBox" Content="Show system tray on hover" Margin="0,187,0,0" VerticalAlignment="Top" Checked="showTrayOnHoverCheckBox_Checked" Unchecked="showTrayOnHoverCheckBox_Unchecked"/>
-            <CheckBox x:Name="compositionFixCheckBox" Content="TranslucentTB compatibility" Margin="0,219,0,0" VerticalAlignment="Top" IsChecked="False" Checked="compositionFixCheckBox_Checked"/>
-            <CheckBox x:Name="fillMaximisedCheckBox" Content="Fill taskbar when maximised" Margin="0,252,0,0" Checked="fillMaximisedCheckBox_Checked"  Unchecked="fillMaximisedCheckBox_Unchecked"  VerticalAlignment="Top" HorizontalAlignment="Center"/>
-            <CheckBox x:Name="fillAltTabCheckBox" Content="Fill taskbar on alt+tab" Margin="0,284,0,0" VerticalAlignment="Top"/>
+            <CheckBox x:Name="showWidgetsCheckBox" Content="Show widgets (Win+F2)" Margin="0,155,0,0" VerticalAlignment="Top"/>
+            <CheckBox x:Name="showTrayCheckBox" Content="Show system tray (Win+F2)" Margin="0,187,0,0" VerticalAlignment="Top"/>
+            <CheckBox x:Name="showTrayOnHoverCheckBox" Content="Show tray/widgets on hover" Margin="0,219,0,0" VerticalAlignment="Top" Checked="showTrayOnHoverCheckBox_Checked" Unchecked="showTrayOnHoverCheckBox_Unchecked"/>
+            <CheckBox x:Name="compositionFixCheckBox" Content="TranslucentTB compatibility" Margin="0,252,0,0" VerticalAlignment="Top" IsChecked="False" Checked="compositionFixCheckBox_Checked"/>
+            <CheckBox x:Name="fillMaximisedCheckBox" Content="Fill taskbar when maximised" Margin="0,284,0,0" Checked="fillMaximisedCheckBox_Checked"  Unchecked="fillMaximisedCheckBox_Unchecked"  VerticalAlignment="Top" HorizontalAlignment="Center"/>
+            <CheckBox x:Name="fillAltTabCheckBox" Content="Fill taskbar on alt+tab" Margin="0,316,0,0" VerticalAlignment="Top"/>
         </Grid>
     </Grid>
 </Window>

--- a/RoundedTB/MainWindow.xaml.cs
+++ b/RoundedTB/MainWindow.xaml.cs
@@ -161,6 +161,7 @@ namespace RoundedTB
                         IsCentred = false,
                         IsWindows11 = true,
                         ShowTray = false,
+                        ShowWidgets = false,
                         CompositionCompat = false,
                         IsNotFirstLaunch = false,
                         FillOnMaximise = true,
@@ -182,6 +183,7 @@ namespace RoundedTB
                         IsCentred = false,
                         IsWindows11 = false,
                         ShowTray = false,
+                        ShowWidgets = false,
                         CompositionCompat = false,
                         IsNotFirstLaunch = false,
                         FillOnMaximise = true,
@@ -208,6 +210,7 @@ namespace RoundedTB
                 $"IsDynamic: {activeSettings.IsDynamic}\n" +
                 $"IsCentred: {activeSettings.IsCentred}\n" +
                 $"ShowTray: {activeSettings.ShowTray}\n" +
+                $"ShowWidgets: {activeSettings.ShowWidgets}\n" +
                 $"CompositionCompat: {activeSettings.CompositionCompat}\n" +
                 $"IsNotFirstLaunch: {activeSettings.IsNotFirstLaunch}\n" +
                 $"FillOnMaximise: {activeSettings.FillOnMaximise}\n" +
@@ -273,6 +276,7 @@ namespace RoundedTB
             dynamicCheckBox.IsChecked = activeSettings.IsDynamic;
             centredCheckBox.IsChecked = activeSettings.IsCentred;
             showTrayCheckBox.IsChecked = activeSettings.ShowTray;
+            showWidgetsCheckBox.IsChecked = activeSettings.ShowWidgets;
             fillMaximisedCheckBox.IsChecked = activeSettings.FillOnMaximise;
             fillAltTabCheckBox.IsChecked = activeSettings.FillOnTaskSwitch;
             showTrayOnHoverCheckBox.IsChecked = activeSettings.ShowTrayOnHover;
@@ -383,6 +387,7 @@ namespace RoundedTB
             activeSettings.IsDynamic = (bool)dynamicCheckBox.IsChecked;
             activeSettings.IsCentred = Taskbar.CheckIfCentred();
             activeSettings.ShowTray = (bool)showTrayCheckBox.IsChecked;
+            activeSettings.ShowWidgets = (bool)showWidgetsCheckBox.IsChecked;
             activeSettings.CompositionCompat = (bool)compositionFixCheckBox.IsChecked;
             activeSettings.FillOnMaximise = (bool)fillMaximisedCheckBox.IsChecked;
             activeSettings.FillOnTaskSwitch = (bool)fillAltTabCheckBox.IsChecked;
@@ -709,6 +714,8 @@ namespace RoundedTB
             showTrayOnHoverCheckBox.IsChecked = false;
             showTrayCheckBox.IsEnabled = true;
             showTrayCheckBox.IsChecked = true;
+            showWidgetsCheckBox.IsEnabled = true;
+            showWidgetsCheckBox.IsChecked = true;
             mLeftLabel.Content = "Outer Margin";
             mRightLabel.Content = "Inner Margin";
 
@@ -734,7 +741,9 @@ namespace RoundedTB
             showTrayOnHoverCheckBox.IsChecked = false;
             showTrayCheckBox.IsEnabled = false;
             showTrayCheckBox.IsChecked = false;
-            
+            showWidgetsCheckBox.IsEnabled = false;
+            showWidgetsCheckBox.IsChecked = false;
+
             if (!isWindows11)
             {
                 splitHelpButton.Visibility = Visibility.Hidden;
@@ -853,12 +862,16 @@ namespace RoundedTB
         {
             showTrayCheckBox.IsEnabled = false;
             showTrayCheckBox.IsChecked = false;
+            showWidgetsCheckBox.IsEnabled = false;
+            showWidgetsCheckBox.IsChecked = false;
         }
 
         private void showTrayOnHoverCheckBox_Unchecked(object sender, RoutedEventArgs e)
         {
             showTrayCheckBox.IsEnabled = true;
             showTrayCheckBox.IsChecked = true;
+            showWidgetsCheckBox.IsEnabled = true;
+            showWidgetsCheckBox.IsChecked = true;
         }
     }
 }

--- a/RoundedTB/Taskbar.cs
+++ b/RoundedTB/Taskbar.cs
@@ -237,6 +237,15 @@ namespace RoundedTB
                     Height = Convert.ToInt32(taskbar.TaskbarRect.Bottom - taskbar.TaskbarRect.Top - (settings.MarginBottom * taskbar.ScaleFactor)) + 1
                 };
 
+                Types.EffectiveRegion widgetsEffectiveRegion = new Types.EffectiveRegion
+                {
+                    CornerRadius = Convert.ToInt32(settings.CornerRadius * taskbar.ScaleFactor),
+                    Top = Convert.ToInt32(settings.MarginTop * taskbar.ScaleFactor),
+                    Left = Convert.ToInt32(settings.MarginLeft * taskbar.ScaleFactor),
+                    Width = Convert.ToInt32(168 * taskbar.ScaleFactor - (settings.MarginRight * taskbar.ScaleFactor)) + 1,
+                    Height = Convert.ToInt32(taskbar.TaskbarRect.Bottom - taskbar.TaskbarRect.Top - (settings.MarginBottom * taskbar.ScaleFactor)) + 1
+                };
+
                 centredDistanceFromEdge = taskbar.TaskbarRect.Right - taskbar.AppListRect.Right - Convert.ToInt32(2 * taskbar.ScaleFactor);
 
                 // If on Windows 10, add an extra 20 logical pixels for the grabhandle
@@ -287,6 +296,22 @@ namespace RoundedTB
                     LocalPInvoke.CombineRgn(finalRegion, trayRegion, mainRegion, 2);
                     mainRegion = finalRegion;
                 }
+
+                if (settings.ShowWidgets)
+                {
+                    IntPtr widgetsRegion = LocalPInvoke.CreateRoundRectRgn(
+                        widgetsEffectiveRegion.Left,
+                        widgetsEffectiveRegion.Top,
+                        widgetsEffectiveRegion.Width,
+                        widgetsEffectiveRegion.Height,
+                        widgetsEffectiveRegion.CornerRadius,
+                        widgetsEffectiveRegion.CornerRadius
+                        );
+
+                    LocalPInvoke.CombineRgn(finalRegion, widgetsRegion, mainRegion, 2);
+                    mainRegion = finalRegion;
+                }
+
 
                 // Apply the final region to the taskbar
                 LocalPInvoke.SetWindowRgn(taskbar.TaskbarHwnd, mainRegion, true);

--- a/RoundedTB/Types.cs
+++ b/RoundedTB/Types.cs
@@ -39,6 +39,7 @@ namespace RoundedTB
             public bool IsCentred { get; set; }
             public bool IsWindows11 { get; set; }
             public bool ShowTray { get; set; }
+            public bool ShowWidgets { get; set; }
             public bool CompositionCompat { get; set; }
             public bool IsNotFirstLaunch { get; set; }
             public bool FillOnMaximise { get; set; }


### PR DESCRIPTION
Looks like the current master and/or other forks are unstable, suffering from various crashes.
I added support for widgets segment on top of the stable 3.1 version